### PR TITLE
Structure for HCI section in sprint 1

### DIFF
--- a/report/src/sprint_1/index.tex
+++ b/report/src/sprint_1/index.tex
@@ -1,4 +1,6 @@
 \chapter{Sprint 1}
 \input{sprint_1/planning.tex}
+\input{sprint_1/prototyping.tex}
+\input{sprint_1/prototype_evaluation.tex}
 % Insert development sections here
 \input{sprint_1/review_retrospective.tex}

--- a/report/src/sprint_1/prototype_evaluation.tex
+++ b/report/src/sprint_1/prototype_evaluation.tex
@@ -1,0 +1,8 @@
+\subsection{Evaluating prototype usability}
+theory about usability evaluation techniques.
+\subsubsection*{Evaluation procedure}
+Hvordan laver vi vores evaluering??? Ingen teori, kun forklaring af Hvordan og hvorfor. 
+\subsection{Afrundings interview}
+teori om coding samt resultater documentation of coding
+\subsection{Results}
+Presentation and delivery of results --> This leads to us gaining new understanding (we need that fancy 'design funnel')

--- a/report/src/sprint_1/prototyping.tex
+++ b/report/src/sprint_1/prototyping.tex
@@ -1,0 +1,7 @@
+\section{Prototyping}
+El teore about prototpying, mockups and hci (how to do mobile)
+(hi-fi, low-fi, mock-up, what we use and why we use it, what do we gain, heuristics etc.)
+(prototyping for mobile units)
+
+\subsection{Developing the prototype}
+Development of prototype


### PR DESCRIPTION
Suggested file and section structure for the hci/prototyping section for sprint 1. 
We suggest to using prototyping.tex to create sections that decribe overall hci theory needed to understand why we create a prototype as well how we create a prototype.
Similarly, we suggest using prototype_evaluation for theory about how to use prototypes, usability evaluation, interview theory, coding theory, and qualitative data analysis theory and application.