### PR TITLE
Weighted KNN implementation

### DIFF
--- a/blazor-application/Services/KnnClassifier.cs
+++ b/blazor-application/Services/KnnClassifier.cs
@@ -21,7 +21,7 @@ public sealed class KnnClassifier
 
     public ClassLabel Classify(int[] rssis, IReadOnlyList<DataPoint> rssiDataPoints)
     {
-        if (k > rssis.Length) return ClassLabel.Outside;
+        if (k > rssiDataPoints.Count) return ClassLabel.Outside;
         
         DataPointDistance[] distances = CalculateDistances(rssis, rssiDataPoints);
         DataPointDistance[] kNearestNeighbors = GetKNearestNeighbors(distances, k);


### PR DESCRIPTION
## kNN Implementation
This implementation is based on the QuickSelect algorithm, which is an efficient selection algorithm for finding the k-th smallest element in an unordered list.

The primary idea behind QuickSelect is to partially sort the data by applying a divide-and-conquer strategy, similar to QuickSort, but with one major difference: in QuickSelect, we only recurse into the partition that contains the k-th smallest element, rather than recursing into both partitions as in QuickSort. This results in an average-case complexity of O(n), making it significantly faster than sorting the entire list.

Here's a brief explanation of the methods used in the provided implementation:
- `GetKNearestNeighbors`: The main method that prepares the data and calls the QuickSelect algorithm. It calls the QuickSelect algorithm to partially sort the array, placing the `k` smallest elements at the beginning of the array. Finally, it copies the first `k` elements into the result array and returns it.
- `QuickSelect`: This method is the core of the QuickSelect algorithm. It takes the distances array, left and right indices, and the desired number of smallest elements k as input. It checks whether the left and right indices are equal; if so, it returns. If not, it chooses a random pivot index, calls the Partition method to partition the array around the pivot, and then recursively calls the QuickSelect method for the partition containing the k-th smallest element.
- `Partition`: This method takes the distances array, left and right indices, and the pivot index as input. It partitions the array around the pivot value, ensuring that elements less than the pivot value are placed to the left of the pivot, while elements greater than the pivot value are placed to the right. It returns the final index of the pivot value after partitioning.
- `Swap`: A simple utility method to swap the elements in the distances array at indices a and b.

The implementation is more performant than sorting the entire list, especially for large datasets. The QuickSelect algorithm has an average-case complexity of `O(n)`, making it a faster solution for finding the `k` smallest elements in an unordered list.

## Weighting to classify
We normalize the weights so that they sum up to 1. This way, we can calculate the probability of the data point being 'inside' the room, and compare it to a threshold to make the final decision.

With this approach, you normalize the weights by dividing each weight by the sum of all inverse distances. This ensures that the weights sum up to 1, allowing us to interpret the `weightedNumNeighborsInsideRoom` as the probability of the data point being 'inside' the room.

We can adjust the threshold value to balance between precision and recall or to meet specific requirements for the application. **A higher threshold will result in a stricter classification for 'inside' the room, while a lower threshold will make it more lenient.**

---

The algorithm steps are shown clearly in the `Classify` function:
```csharp
public ClassLabel Classify(int[] rssis, IReadOnlyList<DataPoint> rssiDataPoints)
{
    DataPointDistance[] distances = CalculateDistances(rssis, rssiDataPoints);
    DataPointDistance[] kNearestNeighbors = GetKNearestNeighbors(distances, k);

    double weightedNumNeighborsInsideRoom = CalculateWeight(kNearestNeighbors, ClassLabel.Inside);

    return weightedNumNeighborsInsideRoom > threshold ? ClassLabel.Inside : ClassLabel.Outside;
}
```

---
We have tested this to ensure correctness.